### PR TITLE
Feat: Implemented static frontend from catalogo page, almost no styling

### DIFF
--- a/projects/livros-app/src/app/app-routing.module.ts
+++ b/projects/livros-app/src/app/app-routing.module.ts
@@ -1,11 +1,17 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { LivrosComponent } from './livros/livros.component';
+import { CatalogoComponent } from './catalogo/catalogo.component'; 
+
 
 const routes: Routes = [
 	{
 		path: 'livros',
 		component: LivrosComponent
+	},
+	{
+		path: 'catalogo',
+		component: CatalogoComponent
 	}
 ];
 

--- a/projects/livros-app/src/app/catalogo/catalogo.component.html
+++ b/projects/livros-app/src/app/catalogo/catalogo.component.html
@@ -1,0 +1,344 @@
+<header class="general-header container space-section">
+  <section class="row height-1hundred-percent">
+    <img class="logo" src="../../assets/logo.png" alt="">
+    <div class="col">
+      <h1>Leia Mais</h1>
+    </div>
+    <nav class="height-1hundred-percent col">
+      <ul ngbNav #nav="ngbNav" [(activeId)]="active" class="gap-2 height-1hundred-percent">
+        <li [ngbNavItem]="1">
+          <button class="btn btn-primary-green button-activated" routerLink="/">Vitrine</button>
+          <ng-template ngbNavContent>Vitrine</ng-template>
+        </li>
+        <li [ngbNavItem]="2">
+          <button class="btn btn-primary-green button-activated" routerLink="/livros">Livros</button>
+          <ng-template ngbNavContent>Livros</ng-template>
+        </li>
+        <li [ngbNavItem]="3">
+          <button class="btn btn-primary-green button-activated">Editoras</button>
+          <ng-template ngbNavContent>Editoras</ng-template>
+        </li>
+      </ul>
+    </nav>
+  </section>
+</header>
+<body class="container space-section">
+  <main class="row">
+    <section class="col">
+      <h2 class="h1-justify">Catálogo de livros</h2>
+    </section>
+    <div class="col">
+      <label for="description-input">Descrição</label>
+      <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Localizar por título, gênero...">
+    </div>
+    <section class="container">
+      <section class="row">
+        <div class="col">
+          <section class="container">
+            <div class="row filters-area">
+              <div class="col">
+                <div ngbDropdown class="d-inline-block">
+                  <button type="button" class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
+                    Toggle dropdown
+                  </button>
+                  <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+                    <button ngbDropdownItem>Action - 1</button>
+                    <button ngbDropdownItem>Another Action</button>
+                    <button ngbDropdownItem>Something else is here</button>
+                  </div>
+                </div>
+              </div>
+              <div class="col">
+                <div ngbDropdown class="d-inline-block">
+                  <button type="button" class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
+                    Toggle dropdown
+                  </button>
+                  <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+                    <button ngbDropdownItem>Action - 1</button>
+                    <button ngbDropdownItem>Another Action</button>
+                    <button ngbDropdownItem>Something else is here</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section class="container between-itemList-items">
+            <section class="row space-section">
+              <div class="col item-list-area">
+                <div class="item-list">
+                  <div class="container">
+                    <div class="row">
+                      <section class="col">
+                        <img class="img-book-list" src="../../assets/logo.png" alt="">
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <section class="row">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <div class="container book-item-info">
+                              <div class="row">
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                              </div>
+                            </div>
+                          </section>
+                        </div>
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <div class="row">
+                            <span>My test</span>
+                          </div>
+                          <div>
+                            <button>My test</button>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col item-list-area">
+                <div class="item-list">
+                  <div class="container">
+                    <div class="row">
+                      <section class="col">
+                        <img class="img-book-list" src="../../assets/logo.png" alt="">
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <section class="row">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <div class="container book-item-info">
+                              <div class="row">
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                              </div>
+                            </div>
+                          </section>
+                        </div>
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <div class="row">
+                            <span>My test</span>
+                          </div>
+                          <div>
+                            <button>My test</button>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="row space-section">
+              <div class="col item-list-area">
+                <div class="item-list">
+                  <div class="container">
+                    <div class="row">
+                      <section class="col">
+                        <img class="img-book-list" src="../../assets/logo.png" alt="">
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <section class="row">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <div class="container book-item-info">
+                              <div class="row">
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                              </div>
+                            </div>
+                          </section>
+                        </div>
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <div class="row">
+                            <span>My test</span>
+                          </div>
+                          <div>
+                            <button>My test</button>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col item-list-area">
+                <div class="item-list">
+                  <div class="container">
+                    <div class="row">
+                      <section class="col">
+                        <img class="img-book-list" src="../../assets/logo.png" alt="">
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <section class="row">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <div class="container book-item-info">
+                              <div class="row">
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                              </div>
+                            </div>
+                          </section>
+                        </div>
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <div class="row">
+                            <span>My test</span>
+                          </div>
+                          <div>
+                            <button>My test</button>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <section class="row space-section">
+              <div class="col item-list-area">
+                <div class="item-list">
+                  <div class="container">
+                    <div class="row">
+                      <section class="col">
+                        <img class="img-book-list" src="../../assets/logo.png" alt="">
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <section class="row">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <div class="container book-item-info">
+                              <div class="row">
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                              </div>
+                            </div>
+                          </section>
+                        </div>
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <div class="row">
+                            <span>My test</span>
+                          </div>
+                          <div>
+                            <button>My test</button>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="col item-list-area">
+                <div class="item-list">
+                  <div class="container">
+                    <div class="row">
+                      <section class="col">
+                        <img class="img-book-list" src="../../assets/logo.png" alt="">
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <section class="row">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <span>My test</span>
+                          </section>
+                          <section class="row between-itemList-items">
+                            <div class="container book-item-info">
+                              <div class="row">
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                                <div class="col">
+                                  <span>My test</span>
+                                </div>
+                              </div>
+                            </div>
+                          </section>
+                        </div>
+                      </section>
+                      <section class="col">
+                        <div class="container">
+                          <div class="row">
+                            <span>My test</span>
+                          </div>
+                          <div>
+                            <button>My test</button>
+                          </div>
+                        </div>
+                      </section>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </section>
+        </div>
+      </section>
+    </section>
+  </main>
+</body>
+
+<footer>
+  <section class="space-section">
+    <!--  Put here the GitHub icon/link -->
+  </section>
+</footer>
+
+<router-outlet></router-outlet>
+

--- a/projects/livros-app/src/app/catalogo/catalogo.component.scss
+++ b/projects/livros-app/src/app/catalogo/catalogo.component.scss
@@ -1,0 +1,87 @@
+
+@import "../../../../../node_modules/bootstrap/scss/functions";
+@import "../../../../../node_modules/bootstrap/scss//variables";
+
+$custom-colors: (
+    "primary-green": rgb(119, 204, 204),
+    "primary-orange": rgb(255, 154, 82)
+);
+
+$theme-colors: map-merge($theme-colors, $custom-colors);
+
+.space-section, .between-itemList-items {
+    padding-top: 29px;
+}
+
+.logo {
+    width: 60px !important;
+    height: 35px;
+}
+
+.image-banner {
+    width: 890px;
+    height: 280px;
+}
+
+.image-vitrine-block {
+    width: 248px;
+    height: 150px;
+    justify-content: center;
+    align-items: center;
+}
+
+h1 {
+    color: $orange;
+}
+.general-header {
+    height: 90px;
+}
+
+.height-1hundred-percent {
+height: 100%;
+}
+
+.button-activated {
+    border: none !important;
+    color: #CEF2F1 !important;
+    border-radius: unset !important;
+}
+
+span {
+    justify-content: center;
+}
+
+footer {
+    background-color: #A4BDBC;
+    height: 70px;
+    margin-top: 57px;
+    margin-bottom: 0px;
+}
+
+
+@import "../../../../../node_modules/bootstrap/scss/bootstrap.scss";
+
+// After this section it's all catalogo's mdodule
+
+
+.filters-area {
+    width: 400px;
+}
+
+.item-list {
+    border: 1px solid;
+    border-radius: 5px;
+    border-color: #E7E7E7;
+    width: 461px;
+    height: 171px;
+}
+
+.img-book-list {
+    width: 86px;
+    height: 88px;
+}
+
+.book-item-info {
+    width: 120px;
+    height: 128px;
+}

--- a/projects/livros-app/src/app/catalogo/catalogo.component.spec.ts
+++ b/projects/livros-app/src/app/catalogo/catalogo.component.spec.ts
@@ -1,0 +1,30 @@
+import '@angular/compiler';
+import { TestBed } from '@angular/core/testing';
+import { AppComponent } from './app.component';
+
+describe('AppComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+    }).compileComponents();
+  });
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
+  });
+
+  it(`should have the 'LeiaMais' title`, () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app.title).toEqual('LeiaMais');
+  });
+
+  it('should render title', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, LeiaMais');
+  });
+});

--- a/projects/livros-app/src/app/catalogo/catalogo.component.ts
+++ b/projects/livros-app/src/app/catalogo/catalogo.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { NgbCarouselModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  templateUrl: './catalogo.component.html',
+  styleUrl: './catalogo.component.scss',
+  imports: [
+    NgbCarouselModule, 
+    NgbNavModule, 
+    RouterModule,
+    NgbDropdownModule
+  ],
+})
+export class CatalogoComponent {
+  active = 1;
+}

--- a/projects/livros-app/src/app/catalogo/catalogo.module.ts
+++ b/projects/livros-app/src/app/catalogo/catalogo.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CatalogoComponent } from './catalogo.component'
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+
+
+@NgModule({
+  imports: [
+   CommonModule,
+   BrowserModule,
+   CatalogoComponent,
+   NgbNavModule,
+   NgbDropdownModule,
+   RouterModule.forChild([
+    {
+      path: '',
+      component: CatalogoComponent
+    }
+   ])
+  ]
+})
+export class LivrosModule {}

--- a/projects/livros-app/src/app/livros/livros.component.html
+++ b/projects/livros-app/src/app/livros/livros.component.html
@@ -15,7 +15,7 @@
           <ng-template ngbNavContent>Livros</ng-template>
         </li>
         <li [ngbNavItem]="3">
-          <button class="btn btn-primary-green button-activated">Editoras</button>
+          <button class="btn btn-primary-green button-activated" routerLink="/catalogo">Editoras</button>
           <ng-template ngbNavContent>Editoras</ng-template>
         </li>
       </ul>
@@ -27,116 +27,116 @@
     <section class="col">
       <h1 class="h1-justify">Adicionar um novo livro ao catálogo</h1>
     </section>
-  </main>
-  <form class="container form-group">
-    <section class="row">
-      <div class="col">
-        <fieldset class="container">
-          <div class="row description-picture-area">
-            <h2>Novos</h2>
-            <section class="container">
-              <div class="row">
-                <label for="description-input">Descrição</label>
-                <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
-              </div>
-            </section>
-          </div>
-        </fieldset>
-      </div>
-      <div class="col">
-        <fieldset class="container">
-          <div class="row form-fiels-area">
-            <section class="container">
-              <div class="row">
-                <div class="col">
+    <form class="container form-group">
+      <section class="row">
+        <div class="col">
+          <fieldset class="container">
+            <div class="row description-picture-area">
+              <h2>Novos</h2>
+              <section class="container">
+                <div class="row">
                   <label for="description-input">Descrição</label>
                   <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
                 </div>
-                <div class="col">
-                  <label for="description-input">Descrição</label>
-                  <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+              </section>
+            </div>
+          </fieldset>
+        </div>
+        <div class="col">
+          <fieldset class="container">
+            <div class="row form-fiels-area">
+              <section class="container">
+                <div class="row">
+                  <div class="col">
+                    <label for="description-input">Descrição</label>
+                    <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                  </div>
+                  <div class="col">
+                    <label for="description-input">Descrição</label>
+                    <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                  </div>
                 </div>
-              </div>
-              <div class="row">
-                <div class="col">
-                  <label for="description-input">Descrição</label>
-                  <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
-                </div>
-                <div class="col">
-                  <div ngbDropdown class="d-inline-block">
-                    <button type="button" class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
-                      Toggle dropdown
-                    </button>
-                    <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
-                      <button ngbDropdownItem>Action - 1</button>
-                      <button ngbDropdownItem>Another Action</button>
-                      <button ngbDropdownItem>Something else is here</button>
+                <div class="row">
+                  <div class="col">
+                    <label for="description-input">Descrição</label>
+                    <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                  </div>
+                  <div class="col">
+                    <div ngbDropdown class="d-inline-block">
+                      <button type="button" class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
+                        Toggle dropdown
+                      </button>
+                      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+                        <button ngbDropdownItem>Action - 1</button>
+                        <button ngbDropdownItem>Another Action</button>
+                        <button ngbDropdownItem>Something else is here</button>
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div class="row">
-                <div class="col">
-                  <label for="description-input">Descrição</label>
-                  <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
-                </div>
-                <div class="col">
-                  <div class="container">
-                    <div class="row">
-                      <label>Disponível</label>
-                      <div class="col">
-                        <div class="form-check form-check-inline">
-                          <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1">
-                          <label class="form-check-label" for="inlineRadio1">1</label>
-                        </div>
-                        <div class="form-check form-check-inline">
-                          <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio2" value="option2">
-                          <label class="form-check-label" for="inlineRadio2">2</label>
+                <div class="row">
+                  <div class="col">
+                    <label for="description-input">Descrição</label>
+                    <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                  </div>
+                  <div class="col">
+                    <div class="container">
+                      <div class="row">
+                        <label>Disponível</label>
+                        <div class="col">
+                          <div class="form-check form-check-inline">
+                            <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio1" value="option1">
+                            <label class="form-check-label" for="inlineRadio1">1</label>
+                          </div>
+                          <div class="form-check form-check-inline">
+                            <input class="form-check-input" type="radio" name="inlineRadioOptions" id="inlineRadio2" value="option2">
+                            <label class="form-check-label" for="inlineRadio2">2</label>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div class="row">
-                <div class="col">
-                  <div ngbDropdown class="d-inline-block">
-                    <button type="button" class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
-                      Toggle dropdown
-                    </button>
-                    <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
-                      <button ngbDropdownItem>Action - 1</button>
-                      <button ngbDropdownItem>Another Action</button>
-                      <button ngbDropdownItem>Something else is here</button>
+                <div class="row">
+                  <div class="col">
+                    <div ngbDropdown class="d-inline-block">
+                      <button type="button" class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
+                        Toggle dropdown
+                      </button>
+                      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+                        <button ngbDropdownItem>Action - 1</button>
+                        <button ngbDropdownItem>Another Action</button>
+                        <button ngbDropdownItem>Something else is here</button>
+                      </div>
                     </div>
                   </div>
+                  <div class="col">
+                    <label for="description-input">Descrição</label>
+                    <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                  </div>
                 </div>
-                <div class="col">
-                  <label for="description-input">Descrição</label>
-                  <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                <div class="row">
+                  <div class="col">
+                    <label for="description-input">Descrição</label>
+                    <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                  </div>
+                  <div class="col">
+                    <label for="description-input">Descrição</label>
+                    <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
+                  </div>
                 </div>
-              </div>
-              <div class="row">
-                <div class="col">
-                  <label for="description-input">Descrição</label>
-                  <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
-                </div>
-                <div class="col">
-                  <label for="description-input">Descrição</label>
-                  <input type="text" class="form-control" id="description-input" aria-describedby="descriptionTextBox" placeholder="Insira aqui a descrição do livro">
-                </div>
-              </div>
-            </section>
-          </div>
-        </fieldset>
-      </div>
-    </section>
-    <section class="row">
-      <div class="col">
-        <button class="btn btn-primary-green button-activated">Adicionar</button>
-      </div>
-    </section>
-  </form>
+              </section>
+            </div>
+          </fieldset>
+        </div>
+      </section>
+      <section class="row">
+        <div class="col">
+          <button class="btn btn-primary-green button-activated">Adicionar</button>
+        </div>
+      </section>
+    </form>
+  </main>
 </body>
 
 <footer>

--- a/projects/livros-app/webpack.config.js
+++ b/projects/livros-app/webpack.config.js
@@ -28,8 +28,7 @@ module.exports = {
   },
   plugins: [
     new ModuleFederationPlugin({
-        library: { type: "module" },
-        name: 'livrosApp', // this name needs to match with the entry name
+        name: 'livrosApp', 
         filename: 'remoteEntry.js',
         exposes: {
           './LivrosModule': './projects/livros-app/src/app/livros/livros.module.ts'


### PR DESCRIPTION
Changes:

- Finished the template from Catalo's page on Livros module
- Included all "shared" components in the same file
- Added route to navigate between livros/catalogos, so far no dropbox for it. Need to be implemented

Pending changes created by this feat:

- Break shared components and use it on other MFEs
- Conclude styling from the page
- Treat the responsiveness 
- Adjust the unit tests
- Review the accessibility